### PR TITLE
v2.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,13 @@ jobs:
         run: cargo +nightly fmt --all -- --check
 
       - name: Build
-        run: cargo build --locked --release --all-targets --all-features || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243
+        run: cargo build --locked --release --all-targets --all-features || (cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && echo "cat done")
 
-      - uses: actions-rs/cargo@v1
-        name: Build (Tests)
-        with:
-          command: test
-          args: --locked --no-run --release --all-targets
+      - name: Build (Tests)
+        run: cargo test --locked --no-run --release --all-targets || (cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && echo "cat done")
 
       - name: Clippy
-        run: cargo clippy --locked --release --all-targets --all-features -- -D warnings || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243
+        run: cargo clippy --locked --release --all-targets --all-features -- -D warnings || (cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && echo "cat done")
 
       - uses: actions-rs/cargo@v1
         name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,23 @@ jobs:
       - name: Format
         run: cargo +nightly fmt --all -- --check
 
-      - name: Build
-        run: cargo build --locked --release --all-targets --all-features
+      - uses: actions-rs/cargo@v1
+        name: Build
+        with:
+          command: build
+          args: --locked --release --all-targets --all-features
 
-      - name: Build (Tests)
-        run: cargo test --locked --no-run --release --all-targets
+      - uses: actions-rs/cargo@v1
+        name: Build (Tests)
+        with:
+          command: test
+          args: --locked --no-run --release --all-targets
 
-      - name: Clippy
-        run: cargo clippy --locked --release --all-targets --all-features -- -D warnings
+      - uses: actions-rs/cargo@v1
+        name: Clippy
+        with:
+          command: clippy
+          args: --locked --release --all-targets --all-features -- -D warnings
 
       - uses: actions-rs/cargo@v1
         name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,13 @@ jobs:
         run: cargo +nightly fmt --all -- --check
 
       - name: Build
-        run: cargo build --locked --release --all-targets --all-features || (cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && echo "cat done")
+        run: cargo build --locked --release --all-targets --all-features
 
       - name: Build (Tests)
-        run: cargo test --locked --no-run --release --all-targets || (cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && echo "cat done")
+        run: cargo test --locked --no-run --release --all-targets
 
       - name: Clippy
-        run: cargo clippy --locked --release --all-targets --all-features -- -D warnings || (cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && echo "cat done")
+        run: cargo clippy --locked --release --all-targets --all-features -- -D warnings
 
       - uses: actions-rs/cargo@v1
         name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,7 @@ jobs:
         run: cargo +nightly fmt --all -- --check
 
       - name: Build
-        run:
-          run: sh -c "cargo build --locked --release --all-targets --all-features || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false"
+        run: cargo build --locked --release --all-targets --all-features || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
 
       - uses: actions-rs/cargo@v1
         name: Build (Tests)
@@ -42,7 +41,7 @@ jobs:
           args: --locked --no-run --release --all-targets
 
       - name: Clippy
-        run: sh -c "cargo clippy --locked --release --all-targets --all-features -- -D warnings || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false"
+        run: cargo clippy --locked --release --all-targets --all-features -- -D warnings || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
 
       - uses: actions-rs/cargo@v1
         name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: cargo +nightly fmt --all -- --check
 
       - name: Build
-        run: cargo build --locked --release --all-targets --all-features || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
+        run: cargo build --locked --release --all-targets --all-features || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243
 
       - uses: actions-rs/cargo@v1
         name: Build (Tests)
@@ -41,7 +41,7 @@ jobs:
           args: --locked --no-run --release --all-targets
 
       - name: Clippy
-        run: cargo clippy --locked --release --all-targets --all-features -- -D warnings || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
+        run: cargo clippy --locked --release --all-targets --all-features -- -D warnings || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243
 
       - uses: actions-rs/cargo@v1
         name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,10 @@ jobs:
       - name: Format
         run: cargo +nightly fmt --all -- --check
 
-      - uses: actions-rs/cargo@v1
-        name: Build
-        with:
-          command: build
-          args: --locked --release --all-targets --all-features
+      - name: Build
+        run:
+          run: |
+            cargo build --locked --release --all-targets --all-features | cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
 
       - uses: actions-rs/cargo@v1
         name: Build (Tests)
@@ -43,11 +42,9 @@ jobs:
           command: test
           args: --locked --no-run --release --all-targets
 
-      - uses: actions-rs/cargo@v1
-        name: Clippy
-        with:
-          command: clippy
-          args: --locked --release --all-targets --all-features -- -D warnings
+      - name: Clippy
+        run: |
+          cargo clippy --locked --release --all-targets --all-features -- -D warnings | cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
 
       - uses: actions-rs/cargo@v1
         name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
 
       - name: Build
         run:
-          run: |
-            cargo build --locked --release --all-targets --all-features | cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
+          run: cargo build --locked --release --all-targets --all-features || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
 
       - uses: actions-rs/cargo@v1
         name: Build (Tests)
@@ -43,8 +42,7 @@ jobs:
           args: --locked --no-run --release --all-targets
 
       - name: Clippy
-        run: |
-          cargo clippy --locked --release --all-targets --all-features -- -D warnings | cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
+        run: cargo clippy --locked --release --all-targets --all-features -- -D warnings || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
 
       - uses: actions-rs/cargo@v1
         name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build
         run:
-          run: cargo build --locked --release --all-targets --all-features || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
+          run: sh -c "cargo build --locked --release --all-targets --all-features || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false"
 
       - uses: actions-rs/cargo@v1
         name: Build (Tests)
@@ -42,7 +42,7 @@ jobs:
           args: --locked --no-run --release --all-targets
 
       - name: Clippy
-        run: cargo clippy --locked --release --all-targets --all-features -- -D warnings || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false
+        run: sh -c "cargo clippy --locked --release --all-targets --all-features -- -D warnings || cat /home/vados/actions-runner/_work/substrate-weight-compare/substrate-weight-compare/target/release/build/sailfish-compiler-59c25d47ed6b9a15/out/templates/root-fab546a76fe1e243 && false"
 
       - uses: actions-rs/cargo@v1
         name: Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "assert_cmd",
  "clap 4.1.8",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "clap 4.1.8",
  "criterion",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "swc_web"
-version = "2.0.2"
+version = "2.1.0"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464e0fddc668ede5f26ec1f9557a8d44eda948732f40c6b0ad79126930eb775f"
+checksum = "cd3cb42f9566ab176e1ef0b8b3a896529062b4efc6be0123046095914c4c1c96"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa9362663c8643d67b2d5eafba49e4cb2c8a053a29ed00a0bea121f17c76b13"
+checksum = "2262160a7ae29e3415554a3f1fc04c764b1540c116aa524683208078b7a75bc9"
 dependencies = [
  "actix-router",
  "proc-macro2",
@@ -549,13 +549,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.6"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
- "clap_lex 0.3.1",
+ "clap_lex 0.3.2",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -1077,9 +1077,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1283,9 +1283,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -1316,9 +1316,9 @@ checksum = "9028f49264629065d057f340a86acb84867925865f73bbf8d47b4d149a7e88b8"
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
@@ -1401,9 +1401,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -1768,15 +1768,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,7 +2070,7 @@ name = "swc"
 version = "2.0.2"
 dependencies = [
  "assert_cmd",
- "clap 4.1.6",
+ "clap 4.1.8",
  "comfy-table",
  "env_logger",
  "log",
@@ -2093,7 +2084,7 @@ dependencies = [
 name = "swc_core"
 version = "2.0.2"
 dependencies = [
- "clap 4.1.6",
+ "clap 4.1.8",
  "criterion",
  "fancy-regex",
  "git-version",
@@ -2119,7 +2110,7 @@ dependencies = [
  "assert_cmd",
  "badge-maker",
  "cached",
- "clap 4.1.6",
+ "clap 4.1.8",
  "dashmap",
  "env_logger",
  "fancy-regex",
@@ -2139,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2150,16 +2141,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2205,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "serde",
@@ -2223,9 +2213,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -2257,9 +2247,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2272,7 +2262,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "assert_cmd",
  "clap 4.1.8",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "clap 4.1.8",
  "criterion",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "swc_web"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "actix-files",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,16 +44,16 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0070905b2c4a98d184c4e81025253cb192aa8a73827553f38e9410801ceb35bb"
+checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash",
+ "ahash 0.8.3",
  "base64 0.21.0",
  "bitflags",
  "brotli",
@@ -188,7 +188,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "actix-web-codegen",
- "ahash",
+ "ahash 0.7.6",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -238,6 +238,18 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
@@ -1864,9 +1876,8 @@ checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "sailfish"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1369644089e936dea5df0d6201636e2b6eb2e9ad098efb2eca5606ece3fab7"
+version = "0.7.0"
+source = "git+https://github.com/ggwpez/sailfish?branch=master#d55cf6333dcc91a2df35e357e2a9767e257d9c2a"
 dependencies = [
  "itoap",
  "ryu",
@@ -1876,9 +1887,8 @@ dependencies = [
 
 [[package]]
 name = "sailfish-compiler"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761019f0de360c654d51e068f07acfa8677e9566391ca290e1ab7c53a55d8d02"
+version = "0.7.0"
+source = "git+https://github.com/ggwpez/sailfish?branch=master#d55cf6333dcc91a2df35e357e2a9767e257d9c2a"
 dependencies = [
  "filetime",
  "home",
@@ -1892,9 +1902,8 @@ dependencies = [
 
 [[package]]
 name = "sailfish-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad9a1a51d085aa939115cf537c71b1e438de7d27363a039ce525bf393262303"
+version = "0.7.0"
+source = "git+https://github.com/ggwpez/sailfish?branch=master#d55cf6333dcc91a2df35e357e2a9767e257d9c2a"
 dependencies = [
  "proc-macro2",
  "sailfish-compiler",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,8 +12,8 @@ swc_core = { version = "2.0.0", path = "../core" }
 
 env_logger = "0.10.0"
 log = "0.4.17"
-clap = { version = "4.1.6", features = ["derive"] }
-syn = { version = "1.0.107", features = ["parsing", "full"] }
+clap = { version = "4.1.8", features = ["derive"] }
+syn = { version = "1.0.109", features = ["parsing", "full"] }
 comfy-table = { version = "6.1.4", default-features = false }
 serde = { version = "1.0.152", features = [ "derive" ] }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2021"
 authors = ["Oliver Tale-Yazdi <oliver.tale-yazdi@parity.io>"]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 authors = ["Oliver Tale-Yazdi <oliver.tale-yazdi@parity.io>"]
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -97,7 +97,7 @@ struct CompareCommitsCmd {
 #[derive(Debug, Parser)]
 struct ParseFilesCmd {
 	/// The files to parse.
-	#[clap(long, index = 1, required(true), num_args = 0..00)]
+	#[clap(long, index = 1, required(true), num_args = 0..1000)]
 	pub files: Vec<PathBuf>,
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_core"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 authors = ["Oliver Tale-Yazdi <oliver.tale-yazdi@parity.io>"]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ chain = []
 bloat = []
 
 [dependencies]
-clap = { version = "4.1.6", features = ["derive"] }
+clap = { version = "4.1.8", features = ["derive"] }
 fancy-regex = "0.11.0"
 git-version = "0.3.5"
 glob = "0.3.1"
@@ -37,7 +37,7 @@ proc-macro2 = "1.0.51"
 semver = "1.0.16"
 serde = { version = "1.0.152", features = [ "derive" ] }
 serde_json = "1.0.93"
-syn = { version = "1.0.107", features = ["parsing", "full"] }
+syn = { version = "1.0.109", features = ["parsing", "full"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = [ "html_reports" ] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_core"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2021"
 authors = ["Oliver Tale-Yazdi <oliver.tale-yazdi@parity.io>"]
 

--- a/core/src/parse/pallet.rs
+++ b/core/src/parse/pallet.rs
@@ -396,7 +396,7 @@ pub(crate) fn parse_parts_args(args: &Punctuated<Expr, Token![,]>) -> Result<Chr
 	if args.len() != 2 {
 		return Err(format!("Expected two arguments for `from_parts`, got {}", args.len()))
 	}
-	
+
 	let a = parse_parts_expr(&args[0])?;
 	let b = parse_parts_expr(&args[1])?;
 	Ok(ChromaticTerm::Value((a, b).into()))

--- a/core/src/parse/pallet.rs
+++ b/core/src/parse/pallet.rs
@@ -384,18 +384,22 @@ fn parse_scalar_call(call: &ExprCall) -> Result<SimpleTerm> {
 	}
 }
 
+pub(crate) fn parse_parts_expr(expr: &Expr) -> Result<u128> {
+	match expr {
+		Expr::Lit(lit) => Ok(lit_to_value(&lit.lit)),
+		Expr::Cast(cast) => parse_parts_expr(&cast.expr),
+		_ => Err("Expected literal expression for `from_parts`".into()),
+	}
+}
+
 pub(crate) fn parse_parts_args(args: &Punctuated<Expr, Token![,]>) -> Result<ChromaticTerm> {
 	if args.len() != 2 {
 		return Err(format!("Expected two arguments for `from_parts`, got {}", args.len()))
 	}
-	match (&args[0], &args[1]) {
-		(Expr::Lit(lit), Expr::Lit(lit2)) => {
-			let n = lit_to_value(&lit.lit);
-			let d = lit_to_value(&lit2.lit);
-			Ok(ChromaticTerm::Value((n, d).into()))
-		},
-		_ => Err("Expected literal arguments for `from_parts`".into()),
-	}
+	
+	let a = parse_parts_expr(&args[0])?;
+	let b = parse_parts_expr(&args[1])?;
+	Ok(ChromaticTerm::Value((a, b).into()))
 }
 
 pub(crate) fn parse_ref_time_args(expr: &Punctuated<Expr, Token![,]>) -> Result<ChromaticTerm> {

--- a/core/src/test/parse/pallet.rs
+++ b/core/src/test/parse/pallet.rs
@@ -258,6 +258,15 @@ fn parse_expression_works_v15(#[case] input: &str, #[case] want: SimpleTerm) {
 			Box::new(Term::Var("s".into())),
 		))),
 ))]
+#[case("Weight::from_parts(0 as u64, 0)
+.saturating_add(Weight::from_parts(520 as u64, 0).saturating_mul(x as u64))"
+	, Term::Add(
+		Box::new(Term::Value((0, 0).into())),
+		Box::new(Term::Mul(
+			Box::new(Term::Value((520, 0).into())),
+			Box::new(Term::Var("x".into())),
+		)),
+	))]
 fn chromatic_syntax(#[case] input: &str, #[case] want: ChromaticTerm) {
 	let expr: Expr = syn::parse_str(input).unwrap();
 	let got = parse_expression(&expr).unwrap();

--- a/core/src/test/parse/pallet.rs
+++ b/core/src/test/parse/pallet.rs
@@ -20,7 +20,7 @@ use crate::{
 #[case("../test_data/new/pallet_staking.rs.txt")]
 #[case("../test_data/old/pallet_staking.rs.txt")]
 #[case("../test_data/new/staking_chromatic.rs.txt")]
-#[case("/home/vados/work/swc/test_data/new/staking_chromatic.rs.txt")]
+#[case("../test_data/new/staking_chromatic.rs.txt")]
 fn parses_weight_files(#[case] path: PathBuf) {
 	if let Err(err) = parse_file(&path) {
 		panic!("Failed to parse file: {:?} with error: {:?}", path, err);

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -14,14 +14,14 @@ polkadot = []
 [dependencies]
 swc_core = { version = "2.0.0", path = "../core" }
 
-actix-web = { version = "4.3.0", features = ["openssl"] }
+actix-web = { version = "4.3.1", features = ["openssl"] }
 actix-files = "0.6.2"
-clap = { version = "4.1.6", features = ["derive"] }
+clap = { version = "4.1.8", features = ["derive"] }
 env_logger = "0.10.0"
 lazy_static = "1.4.0"
 log = "0.4.17"
 openssl = { version = "0.10", features = ["v110"] }
-syn = { version = "1.0.107", features = ["parsing", "full"] }
+syn = { version = "1.0.109", features = ["parsing", "full"] }
 serde = { version = "1.0.152", features = [ "derive" ] }
 sailfish = "0.6.0"
 badge-maker = "0.3.1"
@@ -34,5 +34,5 @@ html-escape = "0.2.13"
 assert_cmd = "2.0.8"
 serial_test = "*"
 reqwest = { version = "0.11.14", default-features = false, features = ["blocking"] }
-tempfile = "3.3.0"
+tempfile = "3.4.0"
 rstest = { version = "0.16.0", default-features = false }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_web"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 authors = ["Oliver Tale-Yazdi <oliver.tale-yazdi@parity.io>"]
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_web"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2021"
 authors = ["Oliver Tale-Yazdi <oliver.tale-yazdi@parity.io>"]
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.17"
 openssl = { version = "0.10", features = ["v110"] }
 syn = { version = "1.0.109", features = ["parsing", "full"] }
 serde = { version = "1.0.152", features = [ "derive" ] }
-sailfish = "0.6.0"
+sailfish = { version  = "0.7.0", git = "https://github.com/ggwpez/sailfish", branch = "master" }
 badge-maker = "0.3.1"
 dashmap = "5.4.0"
 cached = "0.42.0"

--- a/web/static/merge_requests.js
+++ b/web/static/merge_requests.js
@@ -85,13 +85,8 @@ $(document).ready(function () {
 				last_push.toLocaleDateString(),
 			]).draw().node();
 
-			if (should_highlight(mr)) {
-				$(row).css('color', 'seagreen');
-				highlighted++;
-			}
-
 			// Create a double-click handler for the row:
-			(function (mr) {
+			let click_compare = (function (mr) {
 				$(row).dblclick(function() {
 					loading(true);
 					let params = new URLSearchParams(default_params(repo));
@@ -108,7 +103,23 @@ $(document).ready(function () {
 				/*$(row).click(function() {
 					window.location.href = mr.html_url;
 				});*/
-			})(mr);
+			});
+			let disable = (function (mr) {
+				// Disable the row.
+				$(row).css('color', 'gray');
+				$(row).attr('title', 'Only paritytech is currently supported as remote.');
+			});
+
+			if (mr['head']['repo']['owner']['login'] != "paritytech") {
+				$(row).css('color', 'gray');
+				disable(mr);
+			} else {
+				if (should_highlight(mr)) {
+					$(row).css('color', 'seagreen');
+					highlighted++;
+				}
+				click_compare(mr);
+			}
 		}
 
 		// Set the 'highlighted' variable.

--- a/web/static/merge_requests.js
+++ b/web/static/merge_requests.js
@@ -107,10 +107,10 @@ $(document).ready(function () {
 			let disable = (function (mr) {
 				// Disable the row.
 				$(row).css('color', 'gray');
-				$(row).attr('title', 'Only paritytech is currently supported as remote.');
+				$(row).attr('title', 'Forks are unsupported. Remote: ' + mr['head']['repo']['owner']['login'] + ' != ' + owner);
 			});
 
-			if (mr['head']['repo']['owner']['login'] != "paritytech") {
+			if (mr['head']['repo']['owner']['login'] != owner) {
 				$(row).css('color', 'gray');
 				disable(mr);
 			} else {


### PR DESCRIPTION
Changes:
- Fix chromatic weight parsing for `from_parts` in the case that one of them is a cast and not a literal.
- Fix `parse files` to actually accept file names.
- Nightlight and make non-Parity MRs as non-clickable since only one remote origin is currently supported.
- Bump deps.

Waiting for https://github.com/paritytech/substrate/pull/13513 to debug the staging deployment.