### PR TITLE
Add `--strip-path-prefix`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 authors = ["Oliver Tale-Yazdi <oliver.tale-yazdi@parity.io>"]
 
@@ -8,7 +8,7 @@ authors = ["Oliver Tale-Yazdi <oliver.tale-yazdi@parity.io>"]
 polkadot = []
 
 [dependencies]
-swc_core = { version = "2.0.0", path = "../core" }
+swc_core = { version = "2.3.0", path = "../core" }
 
 env_logger = "0.10.0"
 log = "0.4.17"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -117,6 +117,22 @@ pub struct FormatParams {
 	/// Disable color output.
 	#[clap(long)]
 	no_color: bool,
+
+	/// Non-regex string to strip common path prefixes from the file paths.
+	///
+	/// Example: `--strip-path-prefix "^runtime/*/src/weights/"`.
+	/// Uses the `fancy_regex` crate.
+	#[clap(long)]
+	strip_path_prefix: Option<String>,
+}
+
+impl FormatParams {
+	pub fn filter_path(&self, path: String) -> String {
+		match self.strip_path_prefix.as_ref() {
+			Some(prefix) => path.strip_prefix(prefix).unwrap_or(&path).to_string(),
+			None => path,
+		}
+	}
 }
 
 #[derive(
@@ -297,14 +313,19 @@ fn print_changes_human(
 
 	// Print all errors
 	for (info, _change) in per_extrinsic.iter().filter_map(|p| p.error().map(|t| (p, t))) {
-		let row =
-			vec![info.file.clone(), info.name.clone(), "-".into(), "-".into(), "ERROR".into()];
+		let row = vec![
+			format.filter_path(info.file.clone()),
+			info.name.clone(),
+			"-".into(),
+			"-".into(),
+			"ERROR".into(),
+		];
 		table.add_row(row);
 	}
 
 	for (info, change) in per_extrinsic.iter().filter_map(|p| p.term().map(|t| (p, t))) {
 		let mut row = vec![
-			info.file.clone(),
+			format.filter_path(info.file.clone()),
 			info.name.clone(),
 			change.old_v.map(|v| unit.fmt_value(v)).unwrap_or_default(),
 			change.new_v.map(|v| unit.fmt_value(v)).unwrap_or_default(),

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 polkadot = []
 
 [dependencies]
-swc_core = { version = "2.0.0", path = "../core" }
+swc_core = { version = "2.3.0", path = "../core" }
 
 actix-web = { version = "4.3.1", features = ["openssl"] }
 actix-files = "0.6.2"


### PR DESCRIPTION
Adds `--strip-path-prefix` to shorten file path the output from:  

```pre
| runtime/polkadot/src/weights/pallet_democracy.rs | cancel_referendum | 114.49us | 245.69us | +114.59
```

to:
```pre
| pallet_democracy.rs | cancel_referendum | 114.49us | 245.69us | +114.59
```
when running with `--strip-path-prefix "runtime/polkadot/src/weights/"`.